### PR TITLE
Add script for protobuf stub generation

### DIFF
--- a/utils/pb/Dockerfile
+++ b/utils/pb/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11
+
+WORKDIR /pb
+
+RUN pip install --no-cache-dir grpcio-tools==1.60.0
+
+CMD ./generate_stubs.sh

--- a/utils/pb/generate_stubs.sh
+++ b/utils/pb/generate_stubs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+proto_dir=$(dirname "$0")
+
+for dir in "$proto_dir"/*; do
+  if [ -d "$dir" ]; then
+    python -m grpc_tools.protoc -I"$dir" --python_out="$dir" --pyi_out="$dir" --grpc_python_out="$dir" "$dir"/*.proto
+  fi
+done
+

--- a/utils/pb/generate_stubs_dockerized.sh
+++ b/utils/pb/generate_stubs_dockerized.sh
@@ -3,4 +3,4 @@ WORKING_DIR=$(dirname "$0")
 cd "$WORKING_DIR"
 
 docker build -t pb-stub-generation "$(pwd)"
-docker run -v "$(pwd):/pb" pb-stub-generation
+docker run -v "$(pwd):/pb" --rm pb-stub-generation

--- a/utils/pb/generate_stubs_dockerized.sh
+++ b/utils/pb/generate_stubs_dockerized.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+WORKING_DIR=$(dirname "$0")
+cd "$WORKING_DIR"
+
+docker build -t pb-stub-generation "$(pwd)"
+docker run -v "$(pwd):/pb" pb-stub-generation


### PR DESCRIPTION
This adds a script creating a small docker container with the required dependencies to generate the python stubs from the `*.proto` files.